### PR TITLE
Mention the use of '*' in printf-formatting specifiers

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3505,16 +3505,20 @@ local: {
   <formalpara>
    <title>Width</title>
    <para>
-    An integer that says how many characters (minimum)
-    this conversion should result in.
+    Either an integer that says how many characters (minimum)
+    this conversion should result in, or <literal>*</literal>.
+    If <literal>*</literal> is used, then the width is supplied
+    as an additional integer value preceding the one formatted
+    by the specifier.
    </para>
   </formalpara>
 
   <formalpara>
    <title>Precision</title>
    <para>
-    A period <literal>.</literal> followed by an integer
-    who&apos;s meaning depends on the specifier:
+    A period <literal>.</literal> optionally followed by
+    either an integer or <literal>*</literal>,
+    whose meaning depends on the specifier:
     <itemizedlist>
      <listitem>
       <simpara>
@@ -3542,7 +3546,9 @@ local: {
     <note>
      <simpara>
       If the period is specified without an explicit value for precision,
-      0 is assumed.
+      0 is assumed. If <literal>*</literal> is used, the precision is
+      supplied as an additional integer value preceding the one formatted
+      by the specifier.
      </simpara>
     </note>
    </para>


### PR DESCRIPTION
When '*' is used to indicate width or precision in a formatting specifier, an additional integer argument is to be supplied which will provide the width/precision to be used.